### PR TITLE
Fix earned field for claims with no new rewards

### DIFF
--- a/scripts/new_rewards_dist.js
+++ b/scripts/new_rewards_dist.js
@@ -111,7 +111,10 @@ async function main() {
 
       // If no new rewards were earned by this claim, keep the previous claim
     } else {
-      combinedClaimsData[stProv] = { ...previousMerkleDist.claims[stProv] };
+      combinedClaimsData[stProv] = {
+        ...previousMerkleDist.claims[stProv],
+        earnedThisDistribution: "0",
+      };
     }
   });
 


### PR DESCRIPTION
When a staking provider has no new rewards earned in the current distribution, the earnedThisDistribution was still showing the value of the previous distribution. This ensures it's explicitly set to "0".

Necessary reviews: 2